### PR TITLE
Made matching of whitespace surrounding keywords non-greedy to correc…

### DIFF
--- a/acme-mode.el
+++ b/acme-mode.el
@@ -40,7 +40,7 @@
     ("^\\(\\.\\(\\sw\\|\\s_\\)+\\)\\>:"
      1 font-lock-function-name-face)
     ;; keywords
-    ("\\s-+\\(lda\\|sta\\|ldx\\|stx\\|ldy\\|sty\\|and\\|ora\\|eor\\|bit\\|cmp\\|cpx\\|cpy\\|adc\\|sbc\\|asl\\|lsr\\|rol\\|ror\\|inc\\|dec\\|jmp\\|jsr\\|brk\\|rts\\|rti\\|php\\|plp\\|pha\\|pla\\|inx\\|dex\\|iny\\|dey\\|tax\\|txa\\|tay\\|tya\\|tsx\\|txs\\|sed\\|cld\\|sei\\|cli\\|sec\\|clc\\|clv\\|beq\\|bne\\|bmi\\|bpl\\|bcc\\|bcs\\|bvc\\|bvs\\|nop\\)\\s-+"
+    ("\\s-+?\\(lda\\|sta\\|ldx\\|stx\\|ldy\\|sty\\|and\\|ora\\|eor\\|bit\\|cmp\\|cpx\\|cpy\\|adc\\|sbc\\|asl\\|lsr\\|rol\\|ror\\|inc\\|dec\\|jmp\\|jsr\\|brk\\|rts\\|rti\\|php\\|plp\\|pha\\|pla\\|inx\\|dex\\|iny\\|dey\\|tax\\|txa\\|tay\\|tya\\|tsx\\|txs\\|sed\\|cld\\|sei\\|cli\\|sec\\|clc\\|clv\\|beq\\|bne\\|bmi\\|bpl\\|bcc\\|bcs\\|bvc\\|bvs\\|nop\\)\\s-+?"
      1 font-lock-keyword-face)
     ;; implicit keywords
     (",[xy]" . font-lock-keyword-face)


### PR DESCRIPTION
…t colouring of several opcodes without operand in sequence. What went wrong was a sequence of e.g. tax pha tay pha etc. Perhaps the whitespace matching rule around keywords can be improved further to a character class of ((start of line|single whitespace)|(end of line|single whitespace)), but my change seems to work ok so far. At least in emacs 24.5.1.